### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ let file = 'C:\\tmp\\convertme.pdf'
 let opts = {
     format: 'jpeg',
     out_dir: path.dirname(file),
-    out_prefix: path.baseName(file, path.extname(file)),
+    out_prefix: path.basename(file, path.extname(file)),
     page: null
 }
 


### PR DESCRIPTION
" baseName is not a function "
This error occurs on running the code.
the actual function is "basename".
Hence function name is corrected for the same.
