### PR TITLE
Improved pdf info parser

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -70,7 +70,7 @@ module.exports = function(file) {
         execFile(path.join(popplerPath, 'pdfinfo'), [file], EXEC_OPTS, (error, stdout, stderr) => {
             if (error) {
                 reject(error);
-            } 
+            }
             else {
                 const nfoObj = parsePdfInfo(stdout);
                 resolve(nfoObj);


### PR DESCRIPTION
- Introduced PDF_METADATA_KEYS array to explicitly define all expected pdfinfo fields.
- Added parsePdfInfo() function to safely parse pdfinfo stdout:
  - Filters only known metadata keys.
  - Normalizes keys to lowercase with underscores.
  - Supports multi-line values.
- Page size is now parsed into width_in_pts and height_in_pts.
- Old direct parsing logic replaced for safety and maintainability.
- Prevents errors if unknown fields appear in pdfinfo output.
